### PR TITLE
ApplicationService constructor injection

### DIFF
--- a/src/services/applicationservice.ts
+++ b/src/services/applicationservice.ts
@@ -37,8 +37,6 @@ export class ApplicationService{
     private _viewTypes: {new(): View}[] = [];
     private _views: View[] = [];
     private _viewSubscribers: ViewSubscriber[] = [];
-    private _eventStore: EventStore = new EventStore();    
-    private _domainService: DomainService = new DomainService(this._eventStore);
     private _domainErrorHandlers: ((error: DomainError) => void)[] = [];
     private _onCommandValidatedHandlers: ((command: IAmACommand) => void)[] = [];
     private _onCommandHandledHandlers: ((command: IAmACommand) => void)[] = [];
@@ -58,7 +56,8 @@ export class ApplicationService{
         this._preCommandValidatingHandlers = [];
     }
 
-    constructor() {
+    constructor(private _eventStore = new EventStore(),
+                private _domainService: DomainService = new DomainService(_eventStore)) {
         var self = this;
         self._eventStore.onEventStored((event) => {
             self._views.forEach((view: View) => {

--- a/tests/services/applicationservice.ts
+++ b/tests/services/applicationservice.ts
@@ -391,22 +391,6 @@ test("application service handles events from injected event store", () => {
     testActionStore.storeEvent(testAction);
     // Assert: ensure callback called
     expect(callback).toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);          
-})
-
-test("application service handles events from injected event store", () => {
-    // Arrange: setup constants
-    const callback = jest.fn(); 
-    const aggregateID = "123";
-    const testAction = new TestAction(aggregateID);
-    const testActionStore = new EventStore();
-    const testDomainService = new DomainService(testActionStore)
-    const testApplicationService = new ApplicationService(testActionStore, testDomainService);
-    testApplicationService.onEventStored(callback)
-    // Act: pass event to store
-    testActionStore.storeEvent(testAction);
-    // Assert: ensure callback called
-    expect(callback).toBeCalled();
     expect(callback.mock.calls.length).toBe(1);  
     testDomainService.getAggregateRoot(TestAggregateRoot, (ar => {
         expect(ar).toBeInstanceOf(TestAggregateRoot);

--- a/tests/services/applicationservice.ts
+++ b/tests/services/applicationservice.ts
@@ -377,3 +377,39 @@ test("application service gets views for registered command validator during val
     expect(callback).toBeCalled();
     expect(callback.mock.calls.length).toBe(1);  
 });
+
+test("application service handles events from injected event store", () => {
+    // Arrange: setup constants
+    const callback = jest.fn(); 
+    const aggregateID = "123";
+    const testAction = new TestAction(aggregateID);
+    const testActionStore = new EventStore();
+    const testDomainService = new DomainService(testActionStore)
+    const testApplicationService = new ApplicationService(testActionStore, testDomainService);
+    testApplicationService.onEventStored(callback)
+    // Act: pass event to store
+    testActionStore.storeEvent(testAction);
+    // Assert: ensure callback called
+    expect(callback).toBeCalled();
+    expect(callback.mock.calls.length).toBe(1);          
+})
+
+test("application service handles events from injected event store", () => {
+    // Arrange: setup constants
+    const callback = jest.fn(); 
+    const aggregateID = "123";
+    const testAction = new TestAction(aggregateID);
+    const testActionStore = new EventStore();
+    const testDomainService = new DomainService(testActionStore)
+    const testApplicationService = new ApplicationService(testActionStore, testDomainService);
+    testApplicationService.onEventStored(callback)
+    // Act: pass event to store
+    testActionStore.storeEvent(testAction);
+    // Assert: ensure callback called
+    expect(callback).toBeCalled();
+    expect(callback.mock.calls.length).toBe(1);  
+    testDomainService.getAggregateRoot(TestAggregateRoot, (ar => {
+        expect(ar).toBeInstanceOf(TestAggregateRoot);
+        expect(ar.ID).toBe(aggregateID);
+    }), aggregateID);
+})


### PR DESCRIPTION
This change allows constructor injection of the DomainService into the ApplicationService, with api backwards compatibility.